### PR TITLE
mlx5_prm.h: Added Virtio acceleration PRM bits

### DIFF
--- a/drivers/net/mlx5/mlx5_prm.h
+++ b/drivers/net/mlx5/mlx5_prm.h
@@ -816,8 +816,19 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8 reserved_at_61f[0x1e1];
 };
 
+struct mlx5_ifc_device_emulation_bits {
+	u8 nvme_offload_type_sqe[0x1];
+	u8 nvme_offload_type_doorbell_only[0x1];
+	u8 nvme_offload_type_command_capsule[0x1];
+	u8 log_max_nvme_offload_namespaces[0x5];
+	u8 reserved_at_8[0x28];
+	u8 registers_size[0x10];
+	u8 reserved_at_100[0x7c0];
+};
+
 union mlx5_ifc_hca_cap_union_bits {
 	struct mlx5_ifc_cmd_hca_cap_bits cmd_hca_cap;
+	struct mlx5_ifc_device_emulation_bits emulation_cap;
 	u8 reserved_at_0[0x8000];
 };
 
@@ -862,6 +873,7 @@ enum {
 
 enum {
 	MLX5_HCA_CAP_GENERAL = 0,
+	MLX5_HCA_CAP_DEVICE_EMULATION = 0x10,
 };
 
 enum {

--- a/drivers/net/mlx5/mlx5_prm.h
+++ b/drivers/net/mlx5/mlx5_prm.h
@@ -938,6 +938,11 @@ enum {
 	MLX5_OBJ_TYPE_VIRTQ = 0x000a,
 };
 
+enum {
+	MLX5_VIRTQ_OBJ_QUEUE_TYPE_RX = 0,
+	MLX5_VIRTQ_OBJ_QUEUE_TYPE_TX = 1,
+};
+
 /* CQE format mask. */
 #define MLX5E_CQE_FORMAT_MASK 0xc
 

--- a/drivers/net/mlx5/mlx5_prm.h
+++ b/drivers/net/mlx5/mlx5_prm.h
@@ -816,6 +816,15 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8 reserved_at_61f[0x1e1];
 };
 
+struct mlx5_ifc_virtio_net_cap_bits {
+	u8 max_num_of_virtqs[0x10];
+	u8 doorbell_bar_offset[0x10];
+	u8 log_doorbell_bar_size[0x8];
+	u8 reserved_at_28[0x18];
+	u8 log_doorbell_stride[0x8];
+	u8 reserved_at_48[0xb8];
+};
+
 struct mlx5_ifc_device_emulation_bits {
 	u8 nvme_offload_type_sqe[0x1];
 	u8 nvme_offload_type_doorbell_only[0x1];
@@ -823,7 +832,9 @@ struct mlx5_ifc_device_emulation_bits {
 	u8 log_max_nvme_offload_namespaces[0x5];
 	u8 reserved_at_8[0x28];
 	u8 registers_size[0x10];
-	u8 reserved_at_100[0x7c0];
+	u8 reserved_at_40[0xc0];
+	struct mlx5_ifc_virtio_net_cap_bits virtnet;
+	u8 reserved_at_200[0x600];
 };
 
 union mlx5_ifc_hca_cap_union_bits {

--- a/drivers/net/mlx5/mlx5_prm.h
+++ b/drivers/net/mlx5/mlx5_prm.h
@@ -877,9 +877,48 @@ struct mlx5_ifc_query_special_contexts_in_bits {
 	u8 reserved_at_40[0x40];
 };
 
+struct mlx5_ifc_general_obj_in_cmd_hdr_bits {
+	u8 opcode[0x10];
+	u8 reserved_at_10[0x20];
+	u8 obj_type[0x10];
+	u8 obj_id[0x20];
+	u8 reserved_at_60[0x20];
+};
+
+struct mlx5_ifc_general_obj_out_cmd_hdr_bits {
+	u8 status[0x8];
+	u8 reserved_at_8[0x18];
+	u8 syndrome[0x20];
+	u8 obj_id[0x20];
+	u8 reserved_at_60[0x20];
+};
+
+struct mlx5_ifc_virtq_bits {
+	u8 reserved_at_0[0x84];
+	u8 queue_type[0x4];
+	u8 qnum[0x18];
+	u8 desc_addr[0x40];
+	u8 used_addr[0x40];
+	u8 available_addr[0x40];
+	u8 doorbell_stride_idx[0x10];
+	u8 queue_size[0x10];
+	u8 ctrl_mkey[0x20];
+	u8 data_mkey[0x20];
+	u8 reserved_at_1c0[0x640];
+};
+
+struct mlx5_ifc_create_virtq_in_bits {
+	struct mlx5_ifc_general_obj_in_cmd_hdr_bits hdr;
+	struct mlx5_ifc_virtq_bits virtq;
+};
+
 enum {
 	MLX5_CMD_OP_QUERY_HCA_CAP = 0x100,
 	MLX5_CMD_OP_QUERY_SPECIAL_CONTEXTS = 0x203,
+	MLX5_CMD_OP_CREATE_GENERAL_OBJECT = 0xa00,
+	MLX5_CMD_OP_MODIFY_GENERAL_OBJECT = 0xa01,
+	MLX5_CMD_OP_QUERY_GENERAL_OBJECT = 0xa02,
+	MLX5_CMD_OP_DESTROY_GENERAL_OBJECT = 0xa03,
 };
 
 enum {
@@ -889,6 +928,14 @@ enum {
 
 enum {
 	MLX5_HCA_CAP_OPMOD_GET_CUR = 1,
+};
+
+enum {
+	MLX5_GENERAL_OBJ_TYPES_CAP_VIRTQ = (1ULL << 10),
+};
+
+enum {
+	MLX5_OBJ_TYPE_VIRTQ = 0x000a,
 };
 
 /* CQE format mask. */

--- a/drivers/net/mlx5/mlx5_prm.h
+++ b/drivers/net/mlx5/mlx5_prm.h
@@ -363,11 +363,11 @@ typedef uint8_t u8;
 
 #define __mlx5_nullp(typ) ((struct mlx5_ifc_##typ##_bits *)0)
 #define __mlx5_bit_sz(typ, fld) sizeof(__mlx5_nullp(typ)->fld)
-#define __mlx5_bit_off(typ, fld) ((unsigned int)(unsigned long) \
-				  (&(__mlx5_nullp(typ)->fld)))
+#define __mlx5_bit_off(typ, fld) (offsetof(struct mlx5_ifc_##typ##_bits, fld))
 #define __mlx5_dw_bit_off(typ, fld) (32 - __mlx5_bit_sz(typ, fld) - \
 				    (__mlx5_bit_off(typ, fld) & 0x1f))
 #define __mlx5_dw_off(typ, fld) (__mlx5_bit_off(typ, fld) / 32)
+#define __mlx5_64_off(typ, fld) (__mlx5_bit_off(typ, fld) / 64)
 #define __mlx5_dw_mask(typ, fld) (__mlx5_mask(typ, fld) << \
 				  __mlx5_dw_bit_off(typ, fld))
 #define __mlx5_mask(typ, fld) ((u32)((1ull << __mlx5_bit_sz(typ, fld)) - 1))
@@ -399,6 +399,8 @@ typedef uint8_t u8;
 #define MLX5_GET(typ, p, fld) ((rte_be_to_cpu_32(*((__be32 *)(p) + \
 		 __mlx5_dw_off(typ, fld))) >> __mlx5_dw_bit_off(typ, fld)) & \
 		__mlx5_mask(typ, fld))
+#define MLX5_GET64(typ, p, fld) (rte_be_to_cpu_64(*((__be64 *)(p) + \
+		__mlx5_64_off(typ, fld))))
 
 struct mlx5_ifc_fte_match_set_misc_bits {
 	u8 reserved_at_0[0x8];


### PR DESCRIPTION
Added the PRM capability and VIRTQ general object commands
related to the VIRTIO acceleration support in the device.

Signed-off-by: Ido Shamay <idos@mellanox.com>