### PR TITLE
net/mlx5_vdpa: Do not fail dev_conf when CREATE_RQ fails

### DIFF
--- a/drivers/net/mlx5/mlx5_vdpa.c
+++ b/drivers/net/mlx5/mlx5_vdpa.c
@@ -113,7 +113,8 @@ static int mlx5_vdpa_setup_rx(struct vdpa_priv *priv)
             rte_vhost_get_vhost_vring(priv->vid, i, &vq);
             if (create_rq(priv, vq.size, i)) {
                 DRV_LOG(ERR, "Create RQ failed for Virtqueue %d", i);
-                return -1;
+                /* TODO(idos): Remove this when FW supports */
+                DRV_LOG(INFO, "Contiuing without RQ for Virtqueue %d", i);
             }
         }
     }


### PR DESCRIPTION
For now FW doesn't support the CREATE_RQ with CQN=0.
For now continue without the CREATE_RQ actually pass.

Signed-off-by: Ido Shamay <idos@mellanox.com>