### PR TITLE
net/mlx5_vdpa: fix rxq cleanup on device close

### DIFF
--- a/drivers/net/mlx5/mlx5_vdpa.c
+++ b/drivers/net/mlx5/mlx5_vdpa.c
@@ -152,6 +152,8 @@ static int mlx5_vdpa_release_rx(struct vdpa_priv *priv)
 	for (i = 0; i < priv->nr_vring; i++) {
 		if (i == 0 || i % 2 == 0) {
 			rq = priv->virtq[i].rq_obj;
+			if (!rq)
+				continue;
 			if (mlx5_glue->dv_devx_obj_destroy(rq)) {
 				DRV_LOG(ERR, "Error DESTROY)RQ VirtQ %d", i);
 				return -1;


### PR DESCRIPTION
If the RQ is not created don't attempt to free it.

Fixes: 6bf7fd642b5b ("net/mlx5_vdpa: Do not fail dev_conf when CREATE_RQ fails")

Signed-off-by: Shahaf Shuler <shahafs@mellanox.com>