### PR TITLE
mlx5_prm.h: Removed duplicated declaration of mlx5_klm

### DIFF
--- a/drivers/net/mlx5/mlx5_prm.h
+++ b/drivers/net/mlx5/mlx5_prm.h
@@ -1216,10 +1216,4 @@ struct mlx5_ifc_create_mkey_in_bits {
 	struct mlx5_ifc_klm_bits klm_pas_mtt[0];
 };
 
-struct mlx5_klm {
-	uint32_t byte_count;
-	uint32_t mkey;
-	uint64_t address;
-};
-
 #endif /* RTE_PMD_MLX5_PRM_H_ */


### PR DESCRIPTION
It was already declared in mlx5_vdpa.c, where it should.

Signed-off-by: Ido Shamay <idos@mellanox.com>